### PR TITLE
Bump version of python formula we require

### DIFF
--- a/formula-requirements.txt
+++ b/formula-requirements.txt
@@ -2,7 +2,7 @@ git@github.com:ministryofjustice/bootstrap-formula.git==v1.0.0
 git@github.com:ministryofjustice/utils-formula.git==v1.0.0
 git@github.com:ministryofjustice/elasticsearch-formula.git==v1.0.2
 git@github.com:ministryofjustice/java-formula.git==v1.0.0
-git@github.com:ministryofjustice/python-formula.git==v1.0.0
+git@github.com:ministryofjustice/python-formula.git==v1.0.2
 git@github.com:ministryofjustice/redis-formula.git==v1.0.0
 git@github.com:ministryofjustice/firewall-formula.git==v1.0.0
 git@github.com:ministryofjustice/nginx-formula.git==v1.0.0


### PR DESCRIPTION
v1.0.0 wasn't actualy a valid version - it didn't have the right
structure.

I really need to add semver to salt shaker
