### PR TITLE
Enable logging of _grokparsefailure messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 1.6.x
+
+* Log _grokparsefailure messages to a file for reprocessing (enabled by default)
+
 ## Version 1.5.3
 
 * Allow specification of statsd output port/host

--- a/logstash/map.jinja
+++ b/logstash/map.jinja
@@ -20,6 +20,7 @@
         'redis': 'monitoring.local',
         'redis_key': 'logstash:beaver',
         'enable_archive_logs': False,
+        'enable_grokparsefailure_logging': True,
         'archive_log_dir': '/var/log/logstash/archive',
         'config_files': [
             '100_input_syslog.conf',
@@ -32,6 +33,7 @@
             '270_filter_haproxy_all.conf',
             '900_output_elasticsearch.conf',
             '910_output_archive.conf',
+            '915_output_grokparsefailure.conf',
             '920_output_statsd_all.conf',
             '921_output_statsd_http_status.conf'
         ],

--- a/logstash/templates/logstash/conf.d/915_output_grokparsefailure.conf
+++ b/logstash/templates/logstash/conf.d/915_output_grokparsefailure.conf
@@ -1,0 +1,14 @@
+{% from "logstash/map.jinja" import logstash with context %}
+output {
+
+{% if logstash.enable_grokparsefailure_logging %}
+    if "_grokparsefailure" in [tags] {
+      file {
+        path => "{{logstash.archive_log_dir}}/grokparsefailure.%{+YYYY-MM-dd}.json_lines.gz"
+        codec => 'json_lines'
+        gzip => true
+      }
+    }
+{% endif %}
+
+}


### PR DESCRIPTION
_grokparsefailure tagged messages have not been processed as expected.

As such, it is important that we log them so that they can be analysed and reprocessed
via the json_lines input.