### PR TITLE
Mark up and send MongoDB log entries; send to statsd; Discovery that ISO8601 processing is problematic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 1.7.x
+
+* Handle mongodb.log: mark-up and send to statsd
+
 ## Version 1.6.0
 
 * Log _grokparsefailure messages to a file for reprocessing (enabled by default)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,8 +20,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     node.vm.synced_folder "vagrant/salt/pillar", "/srv/pillar"
     node.vm.synced_folder "vagrant/salt/root", "/srv/salt"
 
-    node.vm.box = "precise64"
-    node.vm.box_url = "http://files.vagrantup.com/precise64.box"
+    node.vm.box = "mikepea/precise64_bigpkg_salt"
     node.vm.hostname = "logstash"
 
     node.vm.provider "virtualbox" do |v|

--- a/custom-test/spec/240_filter_syslog_all_spec.rb
+++ b/custom-test/spec/240_filter_syslog_all_spec.rb
@@ -46,6 +46,7 @@ describe "240_filter_syslog_all", :our_filters => true do
       # Check that the received_at was converted to a proper timestamp, not a string
       insist { subject["received_at"] }.is_a? Time
       insist { subject["received_at"].iso8601 } == "2014-07-14T02:40:23Z"
+      insist { subject.timestamp.iso8601 } == "2014-07-14T02:40.23Z"
 
     end
   end
@@ -80,6 +81,7 @@ describe "240_filter_syslog_all", :our_filters => true do
       insist { subject["syslog_apparmor_pid"] } == "777"
       insist { subject["syslog_apparmor_comm"] } == "apparmor_parser"
       insist { subject["syslog_apparmor_operation"] } == "profile_replace"
+      insist { subject.timestamp.iso8601 } == "2014-08-29T21:41:59Z"
     end
   end
 
@@ -100,6 +102,7 @@ describe "240_filter_syslog_all", :our_filters => true do
       insist { subject["syslog_apparmor_parent"] } == "15066"
       insist { subject["syslog_apparmor_comm"] } == "python"
       insist { subject["syslog_apparmor_operation"] } == "truncate"
+      insist { subject.timestamp.iso8601 } == "2014-08-29T21:41:59Z"
     end
   end
 
@@ -120,6 +123,7 @@ describe "240_filter_syslog_all", :our_filters => true do
       insist { subject["syslog_apparmor_parent"] } == "15066"
       insist { subject["syslog_apparmor_comm"] } == "python"
       insist { subject["syslog_apparmor_operation"] } == "mknod"
+      insist { subject.timestamp.iso8601 } == "2014-08-29T21:41:59Z"
     end
   end
 

--- a/custom-test/spec/280_filter_mongodb_log_spec.rb
+++ b/custom-test/spec/280_filter_mongodb_log_spec.rb
@@ -37,6 +37,7 @@ describe "280_filter_mongodb_log", :our_filters => true do
       insist { subject["message"] } == line
       insist { subject["mongodb_log_message"] } == '[initandlisten] MongoDB starting : pid=25753 port=27017 dbpath=/data/mongodb 64-bit host=mongo-05.lpa-enh'
       insist { subject["mongodb_log_type_message"] } == 'MongoDB starting : pid=25753 port=27017 dbpath=/data/mongodb 64-bit host=mongo-05.lpa-enh'
+      insist { subject["mongodb_log_timestamp"] } == '2014-11-10T12:46:21.719+0000'
       insist { subject.timestamp.utc.iso8601 } == "2014-11-10T12:46:21Z"
       insist { subject["mongodb_log_subtype"] } == "initandlisten"
     end
@@ -52,6 +53,7 @@ describe "280_filter_mongodb_log", :our_filters => true do
       insist { subject["message"] } == line
       insist { subject["mongodb_log_message"] } == '[conn76798]  authenticate db: local { authenticate: 1, nonce: "xxx", user: "__system", key: "xxx" }'
       insist { subject["mongodb_log_type_message"] } == 'authenticate db: local { authenticate: 1, nonce: "xxx", user: "__system", key: "xxx" }'
+      insist { subject["mongodb_log_timestamp"] } == '2014-12-11T07:49:51.897+0000'
       insist { subject.timestamp.utc.iso8601 } == "2014-12-11T07:49:51Z"
       insist { subject["mongodb_log_subtype"] } == "conn"
       insist { subject["mongodb_log_conn_number"] } == 76798
@@ -62,13 +64,14 @@ describe "280_filter_mongodb_log", :our_filters => true do
 
   describe "type => mongodb_log, conn slow query message" do
 
-    line = %q{2014-11-13T02:02:00.028+0000 [conn4671] getmore opglpa-api.application cursorid:116561480221 ntoreturn:0 exhaust:1 keyUpdates:0 numYields:8 locks(micros) r:174806 nreturned:1418 reslen:4194430 141ms}
+    line = %q{2015-11-13T02:02:00.028+0000 [conn4671] getmore opglpa-api.application cursorid:116561480221 ntoreturn:0 exhaust:1 keyUpdates:0 numYields:8 locks(micros) r:174806 nreturned:1418 reslen:4194430 141ms}
 
     sample "message" => line, "type" => 'mongodb_log', 'tags' => ['mongodb', 'log'] do
       reject { subject["tags"] || [] }.include? "_grokparsefailure"
       insist { subject["message"] } == line
       insist { subject["mongodb_log_type_message"] } == 'getmore opglpa-api.application cursorid:116561480221 ntoreturn:0 exhaust:1 keyUpdates:0 numYields:8 locks(micros) r:174806 nreturned:1418 reslen:4194430 141ms'
-      insist { subject.timestamp.utc.iso8601 } == "2014-11-13T02:02:00Z"
+      insist { subject["mongodb_log_timestamp"] } == '2015-11-13T02:02:00.028+0000'
+      insist { subject.timestamp.utc.iso8601 } == "2015-11-13T02:02:00Z"
       insist { subject["mongodb_log_subtype"] } == "conn"
       insist { subject["mongodb_log_conn_number"] } == 4671
       insist { subject["tags"] || [] }.include? "mongodb_slow_query"

--- a/custom-test/spec/280_filter_mongodb_log_spec.rb
+++ b/custom-test/spec/280_filter_mongodb_log_spec.rb
@@ -23,7 +23,6 @@ describe "280_filter_mongodb_log", :our_filters => true do
   describe "type => mongodb_log, make sure we get @timestamp right" do
     line = %q{2014-11-10T12:46:21.719+0000 [initandlisten] MongoDB starting : pid=25753 port=27017 dbpath=/data/mongodb 64-bit host=mongo-05.lpa-enh}
     sample "message" => line, "type" => 'mongodb_log', 'tags' => ['mongodb', 'log'] do
-      insist { subject["mongodb_log_timestamp"] } == "2014-11-10T12:46:21.719+0000"
       insist { subject.timestamp.utc.iso8601 } == "2014-11-10T12:46:21Z"
     end
   end
@@ -37,7 +36,6 @@ describe "280_filter_mongodb_log", :our_filters => true do
       insist { subject["message"] } == line
       insist { subject["mongodb_log_message"] } == '[initandlisten] MongoDB starting : pid=25753 port=27017 dbpath=/data/mongodb 64-bit host=mongo-05.lpa-enh'
       insist { subject["mongodb_log_type_message"] } == 'MongoDB starting : pid=25753 port=27017 dbpath=/data/mongodb 64-bit host=mongo-05.lpa-enh'
-      insist { subject["mongodb_log_timestamp"] } == '2014-11-10T12:46:21.719+0000'
       insist { subject.timestamp.utc.iso8601 } == "2014-11-10T12:46:21Z"
       insist { subject["mongodb_log_subtype"] } == "initandlisten"
     end
@@ -53,7 +51,6 @@ describe "280_filter_mongodb_log", :our_filters => true do
       insist { subject["message"] } == line
       insist { subject["mongodb_log_message"] } == '[conn76798]  authenticate db: local { authenticate: 1, nonce: "xxx", user: "__system", key: "xxx" }'
       insist { subject["mongodb_log_type_message"] } == 'authenticate db: local { authenticate: 1, nonce: "xxx", user: "__system", key: "xxx" }'
-      insist { subject["mongodb_log_timestamp"] } == '2014-12-11T07:49:51.897+0000'
       insist { subject.timestamp.utc.iso8601 } == "2014-12-11T07:49:51Z"
       insist { subject["mongodb_log_subtype"] } == "conn"
       insist { subject["mongodb_log_conn_number"] } == 76798
@@ -70,7 +67,6 @@ describe "280_filter_mongodb_log", :our_filters => true do
       reject { subject["tags"] || [] }.include? "_grokparsefailure"
       insist { subject["message"] } == line
       insist { subject["mongodb_log_type_message"] } == 'getmore opglpa-api.application cursorid:116561480221 ntoreturn:0 exhaust:1 keyUpdates:0 numYields:8 locks(micros) r:174806 nreturned:1418 reslen:4194430 141ms'
-      insist { subject["mongodb_log_timestamp"] } == '2015-11-13T02:02:00.028+0000'
       insist { subject.timestamp.utc.iso8601 } == "2015-11-13T02:02:00Z"
       insist { subject["mongodb_log_subtype"] } == "conn"
       insist { subject["mongodb_log_conn_number"] } == 4671
@@ -92,8 +88,7 @@ describe "280_filter_mongodb_log", :our_filters => true do
       reject { subject["tags"] || [] }.include? "_grokparsefailure"
       insist { subject["message"] } == line
       insist { subject["mongodb_log_type_message"] } == 'command opglpa-auth.$cmd command: update { update: "token", updates: [ { q: { _id: "e27c2727fdd1ebbc100c1cc0c1abb9b1", scopes: "" }, u: { $set: { expires: 1420472619 } }, multi: false, upsert: false } ], writeConcern: { fsync: false, j: false, wtimeout: 10, w: 1 } } keyUpdates:0 numYields:0  reslen:95 123ms'
-      insist { subject["mongodb_log_timestamp"] } == '2015-01-05T14:28:39.595+0000'
-      #insist { subject.timestamp.utc.iso8601 } == "2015-01-05T14:28:39Z"
+      insist { subject.timestamp.utc.iso8601 } == "2015-01-05T14:28:39Z"
       insist { subject["mongodb_log_subtype"] } == "conn"
       insist { subject["mongodb_log_conn_number"] } == 108385
       insist { subject["tags"] || [] }.include? "mongodb_slow_query"
@@ -114,8 +109,7 @@ describe "280_filter_mongodb_log", :our_filters => true do
       reject { subject["tags"] || [] }.include? "_grokparsefailure"
       insist { subject["message"] } == line
       insist { subject["mongodb_log_type_message"] } == 'command opglpa-api.$cmd command: count { count: "lpaInfo", query: { damage_award: true } } planSummary: COLLSCAN keyUpdates:0 numYields:1 locks(micros) r:183877 reslen:48 109ms'
-      insist { subject["mongodb_log_timestamp"] } == '2015-01-05T15:11:21.824+0000'
-      #insist { subject.timestamp.utc.iso8601 } == "2015-01-05T15:11:21Z"
+      insist { subject.timestamp.utc.iso8601 } == "2015-01-05T15:11:21Z"
       insist { subject["mongodb_log_subtype"] } == "conn"
       insist { subject["mongodb_log_conn_number"] } == 108425
       insist { subject["tags"] || [] }.include? "mongodb_slow_query"

--- a/custom-test/spec/280_filter_mongodb_log_spec.rb
+++ b/custom-test/spec/280_filter_mongodb_log_spec.rb
@@ -84,5 +84,49 @@ describe "280_filter_mongodb_log", :our_filters => true do
 
   end
 
+  describe "type => mongodb_log, conn slow query message -- 2" do
+
+    line = %q{2015-01-05T14:28:39.595+0000 [conn108385] command opglpa-auth.$cmd command: update { update: "token", updates: [ { q: { _id: "e27c2727fdd1ebbc100c1cc0c1abb9b1", scopes: "" }, u: { $set: { expires: 1420472619 } }, multi: false, upsert: false } ], writeConcern: { fsync: false, j: false, wtimeout: 10, w: 1 } } keyUpdates:0 numYields:0  reslen:95 123ms}
+
+    sample "message" => line, "type" => 'mongodb_log', 'tags' => ['mongodb', 'log'] do
+      reject { subject["tags"] || [] }.include? "_grokparsefailure"
+      insist { subject["message"] } == line
+      insist { subject["mongodb_log_type_message"] } == 'command opglpa-auth.$cmd command: update { update: "token", updates: [ { q: { _id: "e27c2727fdd1ebbc100c1cc0c1abb9b1", scopes: "" }, u: { $set: { expires: 1420472619 } }, multi: false, upsert: false } ], writeConcern: { fsync: false, j: false, wtimeout: 10, w: 1 } } keyUpdates:0 numYields:0  reslen:95 123ms'
+      insist { subject["mongodb_log_timestamp"] } == '2015-01-05T14:28:39.595+0000'
+      #insist { subject.timestamp.utc.iso8601 } == "2015-01-05T14:28:39Z"
+      insist { subject["mongodb_log_subtype"] } == "conn"
+      insist { subject["mongodb_log_conn_number"] } == 108385
+      insist { subject["tags"] || [] }.include? "mongodb_slow_query"
+      insist { subject["mongodb_log_query_operation"] } == 'command'
+      insist { subject["mongodb_log_query_database"] } == 'opglpa-auth'
+      insist { subject["mongodb_log_query_collection"] } == '$cmd'
+      insist { subject["mongodb_log_query_duration_ms"] } == 123
+      insist { subject["mongodb_log_query_message"] } == 'command: update { update: "token", updates: [ { q: { _id: "e27c2727fdd1ebbc100c1cc0c1abb9b1", scopes: "" }, u: { $set: { expires: 1420472619 } }, multi: false, upsert: false } ], writeConcern: { fsync: false, j: false, wtimeout: 10, w: 1 } } keyUpdates:0 numYields:0  reslen:95'
+    end
+
+  end
+
+  describe "type => mongodb_log, conn slow query message -- 3" do
+
+    line = %q{2015-01-05T15:11:21.824+0000 [conn108425] command opglpa-api.$cmd command: count { count: "lpaInfo", query: { damage_award: true } } planSummary: COLLSCAN keyUpdates:0 numYields:1 locks(micros) r:183877 reslen:48 109ms}
+
+    sample "message" => line, "type" => 'mongodb_log', 'tags' => ['mongodb', 'log'] do
+      reject { subject["tags"] || [] }.include? "_grokparsefailure"
+      insist { subject["message"] } == line
+      insist { subject["mongodb_log_type_message"] } == 'command opglpa-api.$cmd command: count { count: "lpaInfo", query: { damage_award: true } } planSummary: COLLSCAN keyUpdates:0 numYields:1 locks(micros) r:183877 reslen:48 109ms'
+      insist { subject["mongodb_log_timestamp"] } == '2015-01-05T15:11:21.824+0000'
+      #insist { subject.timestamp.utc.iso8601 } == "2015-01-05T15:11:21Z"
+      insist { subject["mongodb_log_subtype"] } == "conn"
+      insist { subject["mongodb_log_conn_number"] } == 108425
+      insist { subject["tags"] || [] }.include? "mongodb_slow_query"
+      insist { subject["mongodb_log_query_operation"] } == 'command'
+      insist { subject["mongodb_log_query_database"] } == 'opglpa-api'
+      insist { subject["mongodb_log_query_collection"] } == '$cmd'
+      insist { subject["mongodb_log_query_duration_ms"] } == 109
+      insist { subject["mongodb_log_query_message"] } == 'command: count { count: "lpaInfo", query: { damage_award: true } } planSummary: COLLSCAN keyUpdates:0 numYields:1 locks(micros) r:183877 reslen:48'
+    end
+
+  end
+
 
 end

--- a/custom-test/spec/280_filter_mongodb_log_spec.rb
+++ b/custom-test/spec/280_filter_mongodb_log_spec.rb
@@ -1,0 +1,85 @@
+# encoding: utf-8
+
+BEGIN {
+  # Even though all our servers should be in UTC lets check we are dealing with Timezones right.
+  if defined? :org # a.k.a. JRUBY
+    org.joda.time.DateTimeZone.setDefault( org.joda.time.DateTimeZone.forID "America/Los_Angeles" )
+  end
+}
+
+require "test_utils"
+
+describe "280_filter_mongodb_log", :our_filters => true do
+  extend LogStash::RSpec
+
+  # Stub the time out. Since Syslog doesn't include year in it's dates by
+  # default lets make sure we pass past 2014
+  before(:each) do
+    expect(Time).to receive(:now).and_return( Time.local(2014,7,13,19,40,23) )
+  end
+
+  config [ "/etc/logstash/conf.d/280_filter_mongodb_log.conf" ].map { |fn| File.open(fn).read }.reduce(:+)
+
+  describe "type => mongodb_log, make sure we get @timestamp right" do
+    line = %q{2014-11-10T12:46:21.719+0000 [initandlisten] MongoDB starting : pid=25753 port=27017 dbpath=/data/mongodb 64-bit host=mongo-05.lpa-enh}
+    sample "message" => line, "type" => 'mongodb_log', 'tags' => ['mongodb', 'log'] do
+      insist { subject["mongodb_log_timestamp"] } == "2014-11-10T12:46:21.719+0000"
+      insist { subject.timestamp.utc.iso8601 } == "2014-11-10T12:46:21Z"
+    end
+  end
+
+  describe "type => mongodb_log, startup message" do
+
+    line = %q{2014-11-10T12:46:21.719+0000 [initandlisten] MongoDB starting : pid=25753 port=27017 dbpath=/data/mongodb 64-bit host=mongo-05.lpa-enh}
+
+    sample "message" => line, "type" => 'mongodb_log', 'tags' => ['mongodb', 'log'] do
+      reject { subject["tags"] || [] }.include? "_grokparsefailure"
+      insist { subject["message"] } == line
+      insist { subject["mongodb_log_message"] } == '[initandlisten] MongoDB starting : pid=25753 port=27017 dbpath=/data/mongodb 64-bit host=mongo-05.lpa-enh'
+      insist { subject["mongodb_log_type_message"] } == 'MongoDB starting : pid=25753 port=27017 dbpath=/data/mongodb 64-bit host=mongo-05.lpa-enh'
+      insist { subject.timestamp.utc.iso8601 } == "2014-11-10T12:46:21Z"
+      insist { subject["mongodb_log_subtype"] } == "initandlisten"
+    end
+
+  end
+
+  describe "type => mongodb_log, conn message" do
+
+    line = %q{2014-12-11T07:49:51.897+0000 [conn76798]  authenticate db: local { authenticate: 1, nonce: "xxx", user: "__system", key: "xxx" }}
+
+    sample "message" => line, "type" => 'mongodb_log', 'tags' => ['mongodb', 'log'] do
+      reject { subject["tags"] || [] }.include? "_grokparsefailure"
+      insist { subject["message"] } == line
+      insist { subject["mongodb_log_message"] } == '[conn76798]  authenticate db: local { authenticate: 1, nonce: "xxx", user: "__system", key: "xxx" }'
+      insist { subject["mongodb_log_type_message"] } == 'authenticate db: local { authenticate: 1, nonce: "xxx", user: "__system", key: "xxx" }'
+      insist { subject.timestamp.utc.iso8601 } == "2014-12-11T07:49:51Z"
+      insist { subject["mongodb_log_subtype"] } == "conn"
+      insist { subject["mongodb_log_conn_number"] } == 76798
+    end
+
+  end
+
+
+  describe "type => mongodb_log, conn slow query message" do
+
+    line = %q{2014-11-13T02:02:00.028+0000 [conn4671] getmore opglpa-api.application cursorid:116561480221 ntoreturn:0 exhaust:1 keyUpdates:0 numYields:8 locks(micros) r:174806 nreturned:1418 reslen:4194430 141ms}
+
+    sample "message" => line, "type" => 'mongodb_log', 'tags' => ['mongodb', 'log'] do
+      reject { subject["tags"] || [] }.include? "_grokparsefailure"
+      insist { subject["message"] } == line
+      insist { subject["mongodb_log_type_message"] } == 'getmore opglpa-api.application cursorid:116561480221 ntoreturn:0 exhaust:1 keyUpdates:0 numYields:8 locks(micros) r:174806 nreturned:1418 reslen:4194430 141ms'
+      insist { subject.timestamp.utc.iso8601 } == "2014-11-13T02:02:00Z"
+      insist { subject["mongodb_log_subtype"] } == "conn"
+      insist { subject["mongodb_log_conn_number"] } == 4671
+      insist { subject["tags"] || [] }.include? "mongodb_slow_query"
+      insist { subject["mongodb_log_query_operation"] } == 'getmore'
+      insist { subject["mongodb_log_query_database"] } == 'opglpa-api'
+      insist { subject["mongodb_log_query_collection"] } == 'application'
+      insist { subject["mongodb_log_query_duration_ms"] } == 141
+      insist { subject["mongodb_log_query_message"] } == 'cursorid:116561480221 ntoreturn:0 exhaust:1 keyUpdates:0 numYields:8 locks(micros) r:174806 nreturned:1418 reslen:4194430'
+    end
+
+  end
+
+
+end

--- a/logstash/map.jinja
+++ b/logstash/map.jinja
@@ -31,6 +31,7 @@
             '250_filter_nginx_all.conf',
             '260_filter_audit_all.conf',
             '270_filter_haproxy_all.conf',
+            '280_filter_mongodb_log.conf',
             '900_output_elasticsearch.conf',
             '910_output_archive.conf',
             '915_output_grokparsefailure.conf',

--- a/logstash/map.jinja
+++ b/logstash/map.jinja
@@ -36,7 +36,8 @@
             '910_output_archive.conf',
             '915_output_grokparsefailure.conf',
             '920_output_statsd_all.conf',
-            '921_output_statsd_http_status.conf'
+            '921_output_statsd_http_status.conf',
+            '922_output_statsd_mongodb.conf'
         ],
         'statsd_output': {
             'port': '8125',

--- a/logstash/templates/logstash/conf.d/280_filter_mongodb_log.conf
+++ b/logstash/templates/logstash/conf.d/280_filter_mongodb_log.conf
@@ -11,6 +11,7 @@ filter {
 
     date {
       match => [ "mongodb_log_timestamp", "ISO8601" ]
+      remove_field => "mongodb_log_timestamp"
     }
 
     if [mongodb_log_message] {

--- a/logstash/templates/logstash/conf.d/280_filter_mongodb_log.conf
+++ b/logstash/templates/logstash/conf.d/280_filter_mongodb_log.conf
@@ -1,0 +1,44 @@
+filter {
+
+  if [type] == 'mongodb_log' {
+
+    grok {
+      patterns_dir => ["/etc/logstash/patterns"]
+      match => [
+        "message", "%{MONGODB_LOG_BASE}"
+      ]
+    }
+
+    date {
+      match => [ "mongodb_log_timestamp", "ISO8601" ]
+    }
+
+    if [mongodb_log_message] {
+      grok {
+        patterns_dir => ["/etc/logstash/patterns"]
+        match => [
+          "mongodb_log_message", "%{MONGODB_LOG_CONN_TYPE_MESSAGE}",
+          "mongodb_log_message", "%{MONGODB_LOG_TYPE_MESSAGE}"
+        ]
+      }
+    }
+
+    if [mongodb_log_subtype] == 'conn' {
+      if [mongodb_log_type_message] =~ / [0-9]+ms$/ {
+        # slow query message
+        mutate {
+          add_tag => [ "mongodb_slow_query" ]
+        }
+        grok {
+          patterns_dir => ["/etc/logstash/patterns"]
+          match => [
+            "mongodb_log_type_message", "%{MONGODB_LOG_SLOW_QUERY_BASE}"
+          ]
+        }
+      }
+    }
+
+  }
+
+}
+

--- a/logstash/templates/logstash/conf.d/280_filter_mongodb_log.conf
+++ b/logstash/templates/logstash/conf.d/280_filter_mongodb_log.conf
@@ -32,6 +32,7 @@ filter {
         grok {
           patterns_dir => ["/etc/logstash/patterns"]
           match => [
+            "mongodb_log_type_message", "%{MONGODB_LOG_SLOW_QUERY_COMMAND}",
             "mongodb_log_type_message", "%{MONGODB_LOG_SLOW_QUERY_BASE}"
           ]
         }

--- a/logstash/templates/logstash/conf.d/922_output_statsd_mongodb.conf
+++ b/logstash/templates/logstash/conf.d/922_output_statsd_mongodb.conf
@@ -1,0 +1,48 @@
+{% from "logstash/map.jinja" import logstash with context %}
+output {
+
+    if [type] == 'mongodb_log' {
+
+      statsd {
+        port => {{logstash.statsd_output.port}}
+        host => {{logstash.statsd_output.host}}
+        increment => [
+          "mongodb.%{mongodb_log_subtype}"
+        ]
+        sender => "all"
+      }
+
+      # per-host
+      statsd {
+        port => {{logstash.statsd_output.port}}
+        host => {{logstash.statsd_output.host}}
+        increment => [
+          "mongodb.%{mongodb_log_subtype}"
+        ]
+      }
+
+      if "mongodb_slow_query" in [tags] {
+
+        statsd {
+          port => {{logstash.statsd_output.port}}
+          host => {{logstash.statsd_output.host}}
+          timing => [
+            "mongodb.%{mongodb_log_query_operation}", "%{mongodb_log_query_duration_ms}"
+          ]
+          sender => "all"
+        }
+
+        statsd {
+          port => {{logstash.statsd_output.port}}
+          host => {{logstash.statsd_output.host}}
+          timing => [
+            "mongodb.%{mongodb_log_query_operation}", "%{mongodb_log_query_duration_ms}"
+          ]
+        }
+
+      }
+
+    }
+
+}
+

--- a/logstash/templates/logstash/patterns/mongodb_log-pattern
+++ b/logstash/templates/logstash/patterns/mongodb_log-pattern
@@ -11,12 +11,18 @@
 #2014-12-11T07:50:21.912+0000 [initandlisten] connection accepted from 10.3.33.14:40702 #76800 (2 connections now open)
 #2014-12-11T07:50:21.913+0000 [conn76800]  authenticate db: local { authenticate: 1, nonce: "xxx", user: "__system", key: "xxx" }
 
+MONGODB_LOG_SLOW_QUERY_COMMAND   %{MONGODB_LOG_COMMAND_OP:mongodb_log_query_operation} %{MONGO_WORDDASH:mongodb_log_query_database}\.%{MONGODB_LOG_CMD_COLLECTION:mongodb_log_query_collection} %{GREEDYDATA:mongodb_log_query_message} %{INT:mongodb_log_query_duration_ms:int}ms$
+
+MONGODB_LOG_SLOW_QUERY_BASE   %{WORD:mongodb_log_query_operation} %{MONGO_WORDDASH:mongodb_log_query_database}\.%{MONGO_WORDDASH:mongodb_log_query_collection} %{GREEDYDATA:mongodb_log_query_message} %{INT:mongodb_log_query_duration_ms:int}ms$
+
 MONGODB_LOG_BASE              %{TIMESTAMP_ISO8601:mongodb_log_timestamp} +%{GREEDYDATA:mongodb_log_message}
 
 MONGODB_LOG_CONN_TYPE_MESSAGE \[%{MONGODB_LOG_CONN_TYPE:mongodb_log_subtype}%{INT:mongodb_log_conn_number:int}\] +%{GREEDYDATA:mongodb_log_type_message}
 MONGODB_LOG_TYPE_MESSAGE      \[%{MONGODB_LOG_GENERAL_TYPE:mongodb_log_subtype}\] +%{GREEDYDATA:mongodb_log_type_message}
 MONGODB_LOG_CONN_TYPE         conn
 MONGODB_LOG_GENERAL_TYPE      [a-zA-Z0-9 ]+
+MONGODB_LOG_GENERAL_TYPE      [a-zA-Z0-9 ]+
+MONGODB_LOG_COMMAND_OP        command
+MONGODB_LOG_CMD_COLLECTION    \$cmd
 
-MONGODB_LOG_SLOW_QUERY_BASE   %{WORD:mongodb_log_query_operation} %{MONGO_WORDDASH:mongodb_log_query_database}\.%{MONGO_WORDDASH:mongodb_log_query_collection} %{GREEDYDATA:mongodb_log_query_message} %{INT:mongodb_log_query_duration_ms:int}ms$
 

--- a/logstash/templates/logstash/patterns/mongodb_log-pattern
+++ b/logstash/templates/logstash/patterns/mongodb_log-pattern
@@ -1,0 +1,22 @@
+#2014-12-11T07:49:51.896+0000 [initandlisten] connection accepted from 10.3.33.14:40699 #76798 (2 connections now open)
+#2014-12-11T07:49:51.897+0000 [conn76798]  authenticate db: local { authenticate: 1, nonce: "xxx", user: "__system", key: "xxx" }
+#2014-12-11T07:50:09.840+0000 [clientcursormon] mem (MB) res:51 virt:5446
+#2014-12-11T07:50:09.840+0000 [clientcursormon]  mapped (incl journal view):4894
+#2014-12-11T07:50:09.840+0000 [clientcursormon]  connections:2
+#2014-12-11T07:50:09.840+0000 [clientcursormon]  replication threads:32
+#2014-12-11T07:50:21.869+0000 [conn76797] end connection 10.3.33.15:48173 (1 connection now open)
+#2014-12-11T07:50:21.870+0000 [initandlisten] connection accepted from 10.3.33.15:48176 #76799 (2 connections now open)
+#2014-12-11T07:50:21.870+0000 [conn76799]  authenticate db: local { authenticate: 1, nonce: "xxx", user: "__system", key: "xxx" }
+#2014-12-11T07:50:21.911+0000 [conn76798] end connection 10.3.33.14:40699 (1 connection now open)
+#2014-12-11T07:50:21.912+0000 [initandlisten] connection accepted from 10.3.33.14:40702 #76800 (2 connections now open)
+#2014-12-11T07:50:21.913+0000 [conn76800]  authenticate db: local { authenticate: 1, nonce: "xxx", user: "__system", key: "xxx" }
+
+MONGODB_LOG_BASE              %{TIMESTAMP_ISO8601:mongodb_log_timestamp} +%{GREEDYDATA:mongodb_log_message}
+
+MONGODB_LOG_CONN_TYPE_MESSAGE \[%{MONGODB_LOG_CONN_TYPE:mongodb_log_subtype}%{INT:mongodb_log_conn_number:int}\] +%{GREEDYDATA:mongodb_log_type_message}
+MONGODB_LOG_TYPE_MESSAGE      \[%{MONGODB_LOG_GENERAL_TYPE:mongodb_log_subtype}\] +%{GREEDYDATA:mongodb_log_type_message}
+MONGODB_LOG_CONN_TYPE         conn
+MONGODB_LOG_GENERAL_TYPE      [a-zA-Z0-9 ]+
+
+MONGODB_LOG_SLOW_QUERY_BASE   %{WORD:mongodb_log_query_operation} %{MONGO_WORDDASH:mongodb_log_query_database}\.%{MONGO_WORDDASH:mongodb_log_query_collection} %{GREEDYDATA:mongodb_log_query_message} %{INT:mongodb_log_query_duration_ms:int}ms$
+


### PR DESCRIPTION
This PR adds reasonable support for mongodb logs - tagging with 'mongodb_slow_query' where performance data is available.

Message counts and performance data gauges are send to statsd for graphing.

In the process, i discovered that the tests are failing due to incorrect year parsing -- this will cause problems with log replay most likely. See #37 for more details.