### PR TITLE
Add an ability to set `server_name` for the nginx virtual hosts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
+## Version 1.7.2
+
+* Add an ability to set `server_name` for the nginx virtual host for
+  both the Kibana  and Leasticsearch via a pillar. The default value
+  is set via `map.jinja`.
+
 ## Version 1.7.1
+
 * Pin python-daemon so that beaver installs successfully.
 
 ## Version 1.7.0

--- a/logstash/kibana3.sls
+++ b/logstash/kibana3.sls
@@ -1,4 +1,5 @@
 {% from "logstash/map.jinja" import kibana with context %}
+{% from "logstash/map.jinja" import elasticsearch with context %}
 {% from 'utils/apps/lib.sls' import app_skeleton with context %}
 
 include:
@@ -53,7 +54,7 @@ kibana.git:
     - context:
       appslug: kibana
       is_default: False
-      server_name: 'kibana.*'
+      server_name: {{ kibana.server_name }}
       root_dir: /srv/kibana/application/current/src
       index: False
     - watch_in:
@@ -73,7 +74,7 @@ kibana.git:
     - context:
       appslug: elasticsearch
       is_default: False
-      server_name: 'elasticsearch.*'
+      server_name: {{ elasticsearch.server_name }}
       proxy_host: http://localhost
       proxy_port: 9200
     - watch_in:

--- a/logstash/map.jinja
+++ b/logstash/map.jinja
@@ -3,6 +3,7 @@
         'revision': 'v3.0.0milestone5',
         'elasticsearch': '//"+window.location.hostname.replace(/^kibana/,"elasticsearch")+(window.location.port ? ":" + window.location.port : "")+"',
         'es_index': '"kibana-int"',
+        'server_name': 'kibana.*'
     },
     'default': 'Debian',
 }, merge=salt['pillar.get']('kibana', {})) %}
@@ -63,3 +64,10 @@
     },
     'default': 'Debian',
 }, merge=salt['pillar.get']('beaver',{})) %}
+
+{% set elasticsearch = salt['grains.filter_by']({
+    'Debian': {
+      'server_name': 'elasticsearch.*'
+    },
+    'default': 'Debian',
+}, merge=salt['pillar.get']('elasticsearch.',{})) %}


### PR DESCRIPTION
This is concerns both the Kibana and Elasticsearch services.

Signed-off-by: Krzysztof Wilczynski <krzysztof.wilczynski@linux.com>