### PR TITLE
Increase redis input threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Version 1.7.3
+
+* Add an ability to set the number of `redis_input_threads` that
+  logstash consumes from. Default is normally 1, here we have used 6.
+
 ## Version 1.7.2
 
 * Add an ability to set `server_name` for the nginx virtual host for

--- a/logstash/map.jinja
+++ b/logstash/map.jinja
@@ -20,6 +20,7 @@
     'Debian': {
         'redis': 'monitoring.local',
         'redis_key': 'logstash:beaver',
+        'redis_input_threads': 6
         'enable_archive_logs': False,
         'enable_grokparsefailure_logging': True,
         'archive_log_dir': '/var/log/logstash/archive',

--- a/logstash/templates/logstash/conf.d/101_input_redis.conf
+++ b/logstash/templates/logstash/conf.d/101_input_redis.conf
@@ -7,6 +7,7 @@ input {
         data_type => list
         key => '{{ logstash.redis_key }}'
         type => 'logstash:beaver'
+        threads => {{ logstash.redis_input_threads }}
     }
 {% elif logstash.redis is iterable %}
 {% for host in logstash.redis %}
@@ -15,6 +16,7 @@ input {
         data_type => list
         key => '{{ logstash.redis_key }}'
         type => 'logstash:beaver'
+        threads => {{ logstash.redis_input_threads }}
     }
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
Default is to consume from the redis queue using a single thread. This
causes the queue to back up from time-to-time, triggering alerts.
 Increasing the number of threads combined with some alert tuning has
 reduced the number of false alarms considerably.