### PR TITLE
Add ability to customize the redis namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 1.7.X
+
+* Add an ability to customize the `redis_namespace`
+
 ## Version 1.7.3
 
 * Add an ability to set the number of `redis_input_threads` that

--- a/README.rst
+++ b/README.rst
@@ -89,6 +89,7 @@ Example pillar::
       redis:
         host: logstash.local
         port: 6379
+        namespace: logstash:beaver
         db: 0
 
 

--- a/logstash/templates/beaver/beaver.conf
+++ b/logstash/templates/beaver/beaver.conf
@@ -2,6 +2,6 @@
 
 [beaver]
 redis_url: redis://{{beaver.redis.host}}:{{beaver.redis.port}}/{{beaver.redis.db}}
-redis_namespace: logstash:beaver
+redis_namespace: {{ beaver.redis.namespace|default('logstash:beaver') }}
 logstash_version: 1
 queue_timeout: 3600


### PR DESCRIPTION
This is useful when multiple beaver daemons, from different projects send data to a single redis instance, that is consumed by logstash. By having unique namespaces logstash can then be configured to act differently depending on the namespace (ex: save to a different elasticsearch index)