### PR TITLE
Add flag to disable rsyslog udp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## UNRELEASED
+
+* Add option to turn udp logging on and off (syslog:udp_enabled)
+
 ## Version 1.7.6
 
 * Fix logstash beaver by removing the python-pip requirement that is no

--- a/README.rst
+++ b/README.rst
@@ -67,6 +67,13 @@ Pillar variables
   Used to configure whether monitoring should be enabled/installed at all.
   It's useful as client side of monitoring is an implicit dependency.
 
+- syslog:udp_enabled (default True)
+
+  Used to configure whether rsyslogd should forward logs to udp. Set to true
+  by default just for compatibility reasons, but only needed if an endpoint is
+  listening there. Set this to False when using just logstash.client (without
+  logstash.server).
+
 - monitoring:ns (future)
   TODO: Monitoring shall prefix the metrics using this value.
 

--- a/logstash/map.jinja
+++ b/logstash/map.jinja
@@ -11,6 +11,7 @@
 {% set syslog = salt['grains.filter_by']({
     'Debian': {
         'logstash': 'monitoring.local',
+        'udp_enabled': True,
     },
     'default': 'Debian',
 }, merge=salt['pillar.get']('syslog',{})) %}

--- a/logstash/syslog.sls
+++ b/logstash/syslog.sls
@@ -1,13 +1,20 @@
 include:
   - bootstrap.syslog
 
+# Set udp as enabled (by default) so that we don't break current
+# behaviour, but if not, it should delete the previously
+# un-needed file
 /etc/rsyslog.d/10-logstash.conf:
   file:
+{% if salt['pillar.get']('syslog:udp_enabled', True) %}
     - managed
     - source: salt://logstash/templates/syslog/10-logstash.conf
     - template: jinja
     - watch_in:
       - service: rsyslog
+{% else %}
+    - absent
+{% endif %}
 
 /etc/rsyslog.conf:
   file:


### PR DESCRIPTION
When using `logstash.client` by itself rsyslogd will still try to send UDP logging to `monitoring.local` host. This makes sense when there is an endpoint there, but with the current way we do ELK onboarding in the projects we no longer log directly to udp. 

Added a pillar configurable monitoring:udp_enabled (by default `True` so as not to break existing setups when updating) that when set to True it will keep behaviour as it was, otherwise when set to False it will delete the `10-logstash.conf` file from `/etc/rsyslog.d/` and will no longer output logs via udp. 
