### PR TITLE
set bootstrap options for Vagrant greater than 1.7.2 env

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,6 +32,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
       salt.verbose = true
       salt.minion_config = "vagrant/salt/minion"
+      salt.bootstrap_options = "-F -c /tmp -P"
       salt.run_highstate = true
 
     end


### PR DESCRIPTION
After upgrading to a newer version of vagrant 1.7.2 the salt provisioner seems to misbehave.
See  https://github.com/mitchellh/vagrant/issues/6011 and https://github.com/mitchellh/vagrant/issues/6029  for full discussion 

The error was:
```
==> logstash: Running provisioner: salt...
Copying salt minion config to vm.
Checking if salt-minion is installed
salt-minion found
Checking if salt-call is installed
salt-call found
Using Bootstrap Options:  -C
Salt binaries found. Configuring only.
stdin: is not a tty
 * ERROR: In order to run the script in configuration only mode you also need to provide the configuration directory.
Traceback (most recent call last):
  File "<string>", line 1, in <module>
IOError
:
[Errno 32] Broken pipe

The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

/tmp/bootstrap_salt.sh  -C

Stdout from the command:



Stderr from the command:

stdin: is not a tty
 * ERROR: In order to run the script in configuration only mode you also need to provide the configuration directory.
Traceback (most recent call last):
  File "<string>", line 1, in <module>
IOError: [Errno 32] Broken pipe
```
