### PR TITLE
Add pillar options to alter the clients default activated plugins

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
-=======
+========
 logstash
-=======
+========
 
 Formulas to set up and configure the logstash server, or ship logs into a
 central server.
@@ -72,11 +72,11 @@ Pillar variables
 
 
 ``client``
------------
+----------
 
 Install beaver for the ability to ship logs to the central logstash server over
 the redis connection specified in the pillar (with a default of localhost db
-#0)
+#0).
 
 Example usage::
 
@@ -92,9 +92,19 @@ Example pillar::
         namespace: logstash:beaver
         db: 0
 
+You can enable and disable client plugins as below, showing the default values.
+
+Enabling and disabling client plugins::
+
+   beaver:
+      activate_plugins:
+         - salt-master: True
+           salt-minion: True
+           salt-key: True
+           auditd: False
 
 ``logship`` macro
------------
+-----------------
 
 Macro to ship a given log file with beaver to central logstash server.
 
@@ -155,7 +165,7 @@ following pillar::
 
 
 Running Vagrant Tests
-============
+=====================
 
 To run the test suite under Vagrant:
 

--- a/logstash/client.sls
+++ b/logstash/client.sls
@@ -3,10 +3,20 @@ include:
   - .beaver
 
 {% from 'logstash/lib.sls' import logship with context %}
+{% from "logstash/map.jinja" import beaver with context %}
+
+{% if beaver.activate_plugins.get('salt-minion', False) %}
 {{ logship('salt-minion.log', '/var/log/salt/minion', 'salt', ['salt','salt-minion','log'], 'json') }}
+{% endif %}
+{% if beaver.activate_plugins.get('salt-master', False) %}
 {{ logship('salt-master.log', '/var/log/salt/master', 'salt', ['salt','salt-master','log'], 'json') }}
+{% endif %}
+{% if beaver.activate_plugins.get('salt-key', False) %}
 {{ logship('salt-key.log',    '/var/log/salt/key',    'salt', ['salt','salt-key','log'], 'json') }}
+{% endif %}
+{% if beaver.activate_plugins.get('auditd', False) %}
 {{ logship('audit.log', '/var/log/audit/audit.log', 'audit', ['audit'], 'json') }}
+{% endif %}
 
 {#
 we are configuring all 3 to ship even on minions as we can't use wildcard and separate logrotated logs

--- a/logstash/map.jinja
+++ b/logstash/map.jinja
@@ -62,6 +62,12 @@
             'port': 6379,
             'db': 0,
         },
+        'activate_plugins': {
+            'salt-master': True,
+            'salt-minion': True,
+            'salt-key': True,
+            'auditd': False
+        }
     },
     'default': 'Debian',
 }, merge=salt['pillar.get']('beaver',{})) %}


### PR DESCRIPTION
Sometimes we want to be able to enable and disable the default
client plugins activation and only ship the logs we want. This change
adds the option of adding pillar code below to disable auditd

beaver:
      activate_plugins:
        - auditd: False