### PR TITLE
Make queue_timeout available as pillar data.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## UNRELEASED
+
+* Change default queue_timeout to 60 seconds.
+* Provide pillar for redis beaver queue_timeout
+
+
 ## Version 1.8.0
 
 * Add pillar options to alter the clients default activated plugins

--- a/README.rst
+++ b/README.rst
@@ -98,6 +98,7 @@ Example pillar::
         port: 6379
         namespace: logstash:beaver
         db: 0
+        queue_timeout: 60
 
 You can enable and disable client plugins as below, showing the default values.
 

--- a/logstash/map.jinja
+++ b/logstash/map.jinja
@@ -62,6 +62,7 @@
             'host': 'monitoring.local',
             'port': 6379,
             'db': 0,
+            'queue_timeout': 60
         },
         'activate_plugins': {
             'salt-master': True,

--- a/logstash/templates/beaver/beaver.conf
+++ b/logstash/templates/beaver/beaver.conf
@@ -4,4 +4,4 @@
 redis_url: redis://{{beaver.redis.host}}:{{beaver.redis.port}}/{{beaver.redis.db}}
 redis_namespace: {{ beaver.redis.namespace|default('logstash:beaver') }}
 logstash_version: 1
-queue_timeout: 3600
+queue_timeout: {{ beaver.redis.queue_timeout }}


### PR DESCRIPTION
Default queue_timeout value has been reduced to a sensible 60
seconds. Previous value of 3600 secs was problematic with container
restarts.