### PR TITLE
Add absent flag on logship macro.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -142,6 +142,13 @@ format
 
   **Default:** ``json``
 
+absent
+  Boolean flag to force configuration file removal. Deleting a macro
+  call will not remove the configuration file on highstate. Possible
+  values: ``true`` or ``false``
+
+  **Default:** ``false``
+
 Example usage::
 
     include:
@@ -149,6 +156,7 @@ Example usage::
 
     {% from 'logstash/lib.sls' import logship with context %}
     {{ logship('redis-server.log', '/var/log/redis/redis-server.log', 'redis', ['redis','log'], 'json') }}
+    {{ logship('redis-server.log', '/var/log/redis/redis-server.log', 'redis', ['redis','log'], 'json', absent=true) }}
 
 
 apparmor

--- a/logstash/lib.sls
+++ b/logstash/lib.sls
@@ -4,8 +4,8 @@ include:
 
 #}
 
-{% macro logship(appshort, logfile, type='daemon', tags=['daemon','error'], format='json', delimiter='\\\\n') -%}
-{% if salt['pillar.get']('monitoring:enabled', True) %}
+{% macro logship(appshort, logfile, type='daemon', tags=['daemon','error'], format='json', delimiter='\\\\n', absent=False) -%}
+{% if salt['pillar.get']('monitoring:enabled', True) and absent == false %}
 
 {% set tags = ','.join(tags) %}
 
@@ -26,4 +26,10 @@ include:
       - file: /etc/beaver.d
 
 {% endif %}
+
+{% if absent == True %}
+/etc/beaver.d/{{appshort}}.conf:
+  file.absent
+{% endif %}
+
 {%- endmacro %}


### PR DESCRIPTION
If a logship line is removed, then the corresponding configuration file
is not removed from the disk. This flag makes sure that we do remove the
files.