### PR TITLE
When we stop monitoring a file ensure beaver knows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## UNRELEASED
+
+* Fix: Log absent flag should notify beaver and restart if changed
+
 ## v1.8.2
 
 * Add absent flag on logship macro.

--- a/logstash/lib.sls
+++ b/logstash/lib.sls
@@ -29,7 +29,9 @@ include:
 
 {% if absent == True %}
 /etc/beaver.d/{{appshort}}.conf:
-  file.absent
+  file.absent:
+    - watch_in:
+      - service: beaver
 {% endif %}
 
 {%- endmacro %}


### PR DESCRIPTION
Beaver does not restart when we stop monitoring a logfile, so keeps
on shipping, resulting to minion logs getting shipped.