### PR TITLE
Set default key

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,6 +81,11 @@ Pillar variables
 ``client``
 ----------
 
+.. note::
+
+    The formula sets common defaults so in most cases will only require the 
+    states to be loaded in the top.sls file.
+
 Install beaver for the ability to ship logs to the central logstash server over
 the redis connection specified in the pillar (with a default of localhost db
 #0).

--- a/logstash/map.jinja
+++ b/logstash/map.jinja
@@ -1,3 +1,6 @@
+{% set application=salt['grains.get']('Application', 'unknown') %}
+{% set env=salt['grains.get']('Env', 'unknown') %}
+
 {% set kibana = salt['grains.filter_by']({
     'Debian': {
         'revision': 'v3.0.0milestone5',
@@ -59,10 +62,11 @@
 {% set beaver = salt['grains.filter_by']({
     'Debian': {
         'redis': {
-            'host': 'monitoring.local',
+            'host': 'localhost',
             'port': 6379,
             'db': 0,
-            'queue_timeout': 60
+            'queue_timeout': 60,
+            'namespace': 'logstash:' + application + '-' + env
         },
         'activate_plugins': {
             'salt-master': True,


### PR DESCRIPTION
By setting a default for the logstash namespace we can utilise the formula
with sane defaults simply by loading the desired state files.