### PR TITLE
Make cleanup state unique

### DIFF
--- a/logstash/stunnel_scanner.sls
+++ b/logstash/stunnel_scanner.sls
@@ -14,7 +14,7 @@ stunnel_scanner.py:
     - mode: 755
     - template: jinja
 
-cron_cleanup:
+cron_cleanup_stunnel_scanner:
   cmd.run:
     - name: crontab -l | grep -v 'stunnel_scanner.py'  | crontab -
     - require_in:


### PR DESCRIPTION
The name of the cron cleanup state clashes with other formula. This
change makes it more uniquely named.